### PR TITLE
[PATCH] fix age and weight labels for sort in coin control + CSV Export

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -837,13 +837,13 @@ void CoinControlDialog::updateView()
             nInputSum    += nInputSize;
 			
 			// List Mode Weight
-            itemOutput->setText(COLUMN_WEIGHT, QString::number(nTxWeight, 'f',0));
+            itemOutput->setText(COLUMN_WEIGHT, strPad(QString::number((uint64_t)nTxWeight),8," "));
 			
 			// Age
 			uint64_t nAge = GetTime() - out.tx->GetTxTime();
 			double age  = (double)nAge/60/60/24;
 			itemOutput->setText(COLUMN_AGE, QString::number(age, 'f', 2));
-			itemOutput->setText(COLUMN_AGE_int64_t, strPad(QString::number(age), 15, " "));
+			itemOutput->setText(COLUMN_AGE_int64_t, strPad(QString::number(nAge), 15, " "));
 			
 			// Potential Stake
 			double nPotentialStake = 20 / (1 + (nBestHeight / YEARLY_BLOCKCOUNT));

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -605,6 +605,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         return rec->status.countsForBalance;
     case FormattedAmountRole:
         return formatTxAmount(rec, false);
+    case NoteRole:
+        return formatNote(rec);
     case StatusRole:
         return rec->status.status;
     }

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -49,6 +49,8 @@ public:
         ConfirmedRole,
         /** Formatted amount, without brackets when unconfirmed */
         FormattedAmountRole,
+        /** Note field as a converted string */
+        NoteRole,
         /** Transaction status (TransactionRecord::Status) */
         StatusRole
     };

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -48,7 +48,7 @@ TransactionView::TransactionView(QWidget *parent) :
 
     // Export button exposes CSV export functionality
     QPushButton *exportButton = new QPushButton(tr("&Export"), this);
-    exportButton->setToolTip(tr("Export the data in the current tab to a file"));
+    exportButton->setToolTip(tr("Export the data in the current tab to a CSV file"));
     hlayout->addWidget(exportButton);
 
     dateWidget = new QComboBox(this);

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -287,6 +287,10 @@ void TransactionView::updateTotalAmount()
 
 void TransactionView::exportClicked()
 {
+    if (!model || !model->getOptionsModel()) {
+        return;
+    }
+
     // CSV is currently the only supported format
     QString filename = GUIUtil::getSaveFileName(
             this,

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -46,6 +46,11 @@ TransactionView::TransactionView(QWidget *parent) :
     hlayout->addSpacing(23);
 #endif
 
+    // Export button exposes CSV export functionality
+    QPushButton *exportButton = new QPushButton(tr("&Export"), this);
+    exportButton->setToolTip(tr("Export the data in the current tab to a file"));
+    hlayout->addWidget(exportButton);
+
     dateWidget = new QComboBox(this);
 #ifdef Q_OS_MAC
     dateWidget->setFixedWidth(101);
@@ -140,6 +145,8 @@ TransactionView::TransactionView(QWidget *parent) :
     contextMenu->addAction(showDetailsAction);
 
     // Connect actions
+    connect(exportButton, SIGNAL(clicked()), this, SLOT(exportClicked()));
+
     connect(dateWidget, SIGNAL(activated(int)), this, SLOT(chooseDate(int)));
     connect(typeWidget, SIGNAL(activated(int)), this, SLOT(chooseType(int)));
     connect(addressWidget, SIGNAL(textChanged(QString)), this, SLOT(changedPrefix(QString)));
@@ -308,6 +315,7 @@ void TransactionView::exportClicked()
     writer.addColumn(tr("Type"), TransactionTableModel::Type, Qt::EditRole);
     writer.addColumn(tr("Label"), 0, TransactionTableModel::LabelRole);
     writer.addColumn(tr("Address"), 0, TransactionTableModel::AddressRole);
+    writer.addColumn(tr("Note"), 0, TransactionTableModel::NoteRole);
     writer.addColumn(tr("Amount"), 0, TransactionTableModel::FormattedAmountRole);
     writer.addColumn(tr("ID"), 0, TransactionTableModel::TxIDRole);
 


### PR DESCRIPTION
Fixes the sort order for coin weight and age