### PR TITLE
add -static-libgcc to STATIC build flags

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -20,6 +20,7 @@ ifdef STATIC
     LMODE = static
     ifeq (${STATIC}, all)
         LMODE2 = static
+    	DEFS += -static-libgcc
     endif
 endif
 


### PR DESCRIPTION
prevents 
/Pink2/src/netbase.cpp:83: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: cannot find -lgcc_s