### PR TITLE
Flush logs buffer to stdout

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -209,6 +209,7 @@ inline int OutputDebugStringF(const char* pszFormat, ...)
         va_start(arg_ptr, pszFormat);
         ret = vprintf(pszFormat, arg_ptr);
         va_end(arg_ptr);
+        fflush(stdout);
     }
     else if (!fPrintToDebugger)
     {


### PR DESCRIPTION
It forces flushing of logs buffer to stdout with -printtoconsole option passed to daemon on start. Required by non-TTY environments capturing stdout stream and wanting to parse and interpret logs on the fly (e.g. daemon process spawned by Node.js/Electron).