### PR TITLE
Also needs libzip

### DIFF
--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -62,7 +62,7 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-	sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev
+	sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libzip-dev
 
 for Ubuntu 12.04 and later or Debian 7 and later libboost-all-dev has to be installed:
 


### PR DESCRIPTION
I was getting an error that there was no link to -lz when trying to install this on a minimal build headless Debian machine, I needed to install libzip-dev to resolve that.