### PR TITLE
Configurable checkpoints

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -67,7 +67,7 @@ namespace Checkpoints
                 getline(ss, tempStr, ',');
                 uint256 hashCheckpoint(tempStr);
 
-                mapCheckpoints.insert(pair<int, uint256>(nBlockNum, uint256(hashCheckpoint)));
+                mapCheckpoints.insert(pair<int, uint256>(nBlockNum, hashCheckpoint));
             }
         }
     }

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -11,6 +11,7 @@
 #include "main.h"
 #include "uint256.h"
 
+using namespace std;
 
 static const int nCheckpointSpan = 10;
 
@@ -48,6 +49,28 @@ namespace Checkpoints
         boost::assign::map_list_of
         ( 0, hashGenesisBlockTestNet )
     ;
+
+    void GetCheckpointsFromConfig()
+    {
+        if (mapArgs.count("-checkpoint") && mapMultiArgs["-checkpoint"].size() > 0)
+        {
+            for (const string strCheckpoint : mapMultiArgs["-checkpoint"])
+            {
+                stringstream ss(strCheckpoint);
+                string tempStr;
+
+                if (!ss.good()) continue;
+                getline(ss, tempStr, ',');
+                int nBlockNum = atoi(tempStr.c_str());
+
+                if (!ss.good()) continue;
+                getline(ss, tempStr, ',');
+                uint256 hashCheckpoint(tempStr);
+
+                mapCheckpoints.insert(pair<int, uint256>(nBlockNum, uint256(hashCheckpoint)));
+            }
+        }
+    }
 
     bool CheckHardened(int nHeight, const uint256& hash)
     {

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -59,6 +59,8 @@ namespace Checkpoints
     bool SetCheckpointPrivKey(std::string strPrivKey);
     bool SendSyncCheckpoint(uint256 hashCheckpoint);
     bool IsMatureSyncCheckpoint();
+
+    void GetCheckpointsFromConfig();
 }
 
 // ppcoin: synchronized checkpoint

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -278,6 +278,7 @@ std::string HelpMessage()
         "  -forcednsseed          " + _("Always query for peer addresses via DNS lookup (default: 0)") + "\n" +
         "  -staking               " + _("Stake your coins to support network and gain reward (default: 1)") + "\n" +
         "  -synctime              " + _("Sync time with other nodes. Disable if time on your system is precise e.g. syncing with NTP (default: 1)") + "\n" +
+        "  -checkpoint            " + _("Add new checkpoint to hardcoded list") + "\n" +
         "  -cppolicy              " + _("Sync checkpoints policy (default: strict)") + "\n" +
         "  -banscore=<n>          " + _("Threshold for disconnecting misbehaving peers (default: 100)") + "\n" +
         "  -bantime=<n>           " + _("Number of seconds to keep misbehaving peers from reconnecting (default: 86400)") + "\n" +

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -417,6 +417,9 @@ bool AppInit2(boost::thread_group& threadGroup)
     fUseFastIndex = GetBoolArg("-fastindex", true);
     nMinerSleep = GetArg("-minersleep", 800);
 
+    // Parses and adds configurable checkpoints.
+    Checkpoints::GetCheckpointsFromConfig();
+
     CheckpointsMode = Checkpoints::STRICT;
     std::string strCpMode = GetArg("-cppolicy", "strict");
 


### PR DESCRIPTION
Adds new configuration option placed in `pinkconf.txt` / `pinkcoin.conf` file as well as on command line.
Allows extending hardcoded checkpoints list with new ones passed as a wallet configuration. Overwrites of hardcoded checkpoints are ignored.

Example usage in case of issues with syncing to the proper (best) chain:
```
checkpoint=728000,0x00000000002984a1ea9ce4967fca19765a55724234e8479a7f7644c22ee5b30c
checkpoint=730000,0x000000000000768e6ce63ef2ef3c815f5f315273250b8ec82e5d300ef0b65e21 
```

Can be also useful in syncing on testnet (which doesn't have hardcoded checkpoints).