### PR TITLE
FPOS Flip bugfix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1095,7 +1095,7 @@ const CBlockIndex* GetLastBlockIndex(const CBlockIndex* pindex, bool fProofOfSta
 const CBlockIndex* GetLastBlockIndex2(const CBlockIndex* pindex, bool fFlashStake)
 {
     //bool bFlashStake = true;
-    if (pindex->nHeight > 771000) {
+    if (pindex->nHeight >= 771000) {
 
         while (pindex && pindex->pprev && !pindex->IsFPOS(fFlashStake))
             pindex = pindex->pprev;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1095,13 +1095,20 @@ const CBlockIndex* GetLastBlockIndex(const CBlockIndex* pindex, bool fProofOfSta
 const CBlockIndex* GetLastBlockIndex2(const CBlockIndex* pindex, bool fFlashStake)
 {
     //bool bFlashStake = true;
-    while (pindex && pindex->pprev && IsFlashStake(pindex->nTime) != fFlashStake)
-    {
-        pindex = pindex->pprev;
+    if (pindex->nHeight > 771000) {
+
+        while (pindex && pindex->pprev && !pindex->IsFPOS(fFlashStake))
+            pindex = pindex->pprev;
+
+    } else {
+
+        while (pindex && pindex->pprev && IsFlashStake(pindex->nTime) != fFlashStake)
+            pindex = pindex->pprev;
+        while (pindex && pindex->pprev && (!pindex->IsProofOfStake()))
+            pindex = pindex->pprev;
     }
-    while (pindex && pindex->pprev && (!pindex->IsProofOfStake()))
-        pindex = pindex->pprev;
     return pindex;
+
 }
 
 unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfStake, unsigned int nBlockTime)

--- a/src/main.h
+++ b/src/main.h
@@ -1279,10 +1279,10 @@ public:
         return (nFlags & BLOCK_PROOF_OF_STAKE);
     }
 
-    bool IsFlashPOS() const
+    bool IsFPOS(bool nFlash) const
     {
-        if (IsProofOfStake())
-           return (IsFlashStake(nTime));
+       if (IsProofOfStake())
+            return nFlash == IsFlashStake(nTime);
 
         return false;
     }


### PR DESCRIPTION
Clean up implementation of GetLastBlockIndex2 and squash rare FPOS Flip bug.  Will require mandatory update for all users before block 771000 (Approximately February 20th).