### PR TITLE
Fix several UI-related bugs

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -611,8 +611,7 @@ void BitcoinGUI::createMenuBar()
 
     // Configure the menus
 
-    appMenuBar->setMaximumWidth(220);
-
+    appMenuBar->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
 
     QWidget *w = new QWidget(this);
     QHBoxLayout *layout = new QHBoxLayout(w);
@@ -670,10 +669,7 @@ void BitcoinGUI::createMenuBar()
     help->addAction(aboutAction);
     help->addAction(aboutQtAction);
 
-    //appMenuBar->setMaximumWidth(180);
 
-
-	
 	/* zeewolf: Hot swappable wallet themes */
     if (themesList.count()>0)
     {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1618,7 +1618,8 @@ void BitcoinGUI::mousePressEvent(QMouseEvent* event)
     if(event->button() == Qt::LeftButton)
     {
         mMoving = true;
-        mLastMousePosition = event->pos();
+        // Difference between window position and global position of mouse cursor
+        mDiffWindowPosition = this->pos() - event->globalPos();
     }
 }
 
@@ -1626,7 +1627,7 @@ void BitcoinGUI::mouseMoveEvent(QMouseEvent* event)
 {
     if( event->buttons().testFlag(Qt::LeftButton) && mMoving)
     {
-        this->move(this->pos() + (event->pos() - mLastMousePosition));
+        this->move(mDiffWindowPosition + event->globalPos());
     }
 }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -90,23 +90,18 @@ ActiveLabel::ActiveLabel(const QString & text, QWidget * parent):
 
 }
 
-
-/*
-void ActiveLabel::mouseReleaseEvent(QMouseEvent * event)
-{
-    emit clicked();
-}
-*/
-
 bool ActiveLabel::event(QEvent *e)
 {
-//    QHoverEvent me = static_cast<QHoverEvent>(e);
-    if(e->type() == QEvent::HoverMove)
+    if(e->type() == QEvent::MouseButtonPress)
     {
-        //double xpos = me->pos().x();
-        //double ypos = me->pos().y();
+        // Hack: Swallows mouse press event to prevent
+        // from passing it to BitcoinGUI::mousePressEvent
+        // (conflicts with main window grabbing)
+        return true;
+    }
+    else if(e->type() == QEvent::HoverMove)
+    {
         emit hovered();
-        // qDebug() << Q_FUNC_INFO << QString("xpos %1, ypos %2").arg(xpos).arg(ypos);
         return true;
     }
     else if(e->type() == QEvent::HoverLeave)
@@ -122,7 +117,6 @@ bool ActiveLabel::event(QEvent *e)
 
     return QLabel::event(e);
 }
-
 
 
 BitcoinGUI::BitcoinGUI(QWidget *parent):
@@ -1616,6 +1610,7 @@ void BitcoinGUI::mousePressEvent(QMouseEvent* event)
         mMoving = true;
         // Difference between window position and global position of mouse cursor
         mDiffWindowPosition = this->pos() - event->globalPos();
+        setCursor(Qt::ClosedHandCursor);
     }
 }
 
@@ -1632,5 +1627,6 @@ void BitcoinGUI::mouseReleaseEvent(QMouseEvent* event)
     if(event->button() == Qt::LeftButton)
     {
         mMoving = false;
+        unsetCursor();
     }
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -612,6 +612,7 @@ void BitcoinGUI::createMenuBar()
 
     QLabel* pinkCorner = new QLabel(w);
     pinkCorner->setText("<html><head/><body><p><img src=\":/icons/pinkcoin-32\"/></p></body></html>");
+    pinkCorner->setAttribute(Qt::WA_TransparentForMouseEvents);
     layout->addWidget(pinkCorner);
 
     layout->addWidget(appMenuBar);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -45,8 +45,6 @@ signals:
 
 protected:
     bool event(QEvent *e);
-//    void mouseReleaseEvent (QMouseEvent * event) ;
-
 };
 
 /**

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -167,7 +167,7 @@ private:
     /** Create system tray (notification) icon */
     void createTrayIcon();
 
-    QPoint mLastMousePosition;
+    QPoint mDiffWindowPosition;
     bool mMoving;
 
 public slots:

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -131,6 +131,10 @@ OverviewPage::OverviewPage(QWidget *parent) :
     QFont overviewSpend("Ubuntu", 18, QFont::Normal);
     QFont overviewBalances("Ubuntu", 14, QFont::Normal);
 
+    // HACK: Makes that label transparent for mouse events
+    // Mitigates strange event swallowing behavior in main window
+    ui->label_4->setAttribute(Qt::WA_TransparentForMouseEvents);
+
     ui->label->setFont(overviewHeaders);
     ui->label_3->setFont(overviewHeaders);
     ui->label_4->setFont(overviewHeaders);


### PR DESCRIPTION
Fix #22 
Issue was caused by usage of pos() method in mouseMoveEvent for measuring distance traversed by mouse cursor. According to [Qt5 documentation](https://doc.qt.io/qt-5/qmouseevent.html#pos) that method should not be used on X11 systems in mouseMoveEvent method. Changed to use globalPos() instead.

Fix #23 
Issue was caused by setting maximum width for  QMenuBar that with default size policy (QSizePolicy::Preferred) leads to wrong behaviour.

Additional changes:
- mouse cursor changes during window dragging (required two minor hacks).