### PR TITLE
Retargeting fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1108,10 +1108,20 @@ const CBlockIndex* GetLastBlockIndex2(const CBlockIndex* pindex, bool fFlashStak
             pindex = pindex->pprev;
     }
     return pindex;
-
 }
 
+
 unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfStake, unsigned int nBlockTime)
+{
+    if (pindexLast->nHeight < 817990) {
+        return GetNextTargetRequiredV1(pindexLast, fProofOfStake, nBlockTime);
+    }
+    // Fork fixing nActualSpacing calculations for PoS/FPoS blocks
+    // (makes PoS and FPoS next target calculations completelly independent).
+    return GetNextTargetRequiredV2(pindexLast, fProofOfStake, nBlockTime);
+}
+
+unsigned int GetNextTargetRequiredV1(const CBlockIndex* pindexLast, bool fProofOfStake, unsigned int nBlockTime)
 {
     CBigNum bnStakeTarget = bnProofOfStakeLimit;
 
@@ -1120,16 +1130,15 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
 
     CBigNum bnTargetLimit = fProofOfStake ? bnStakeTarget : bnProofOfWorkLimit;
 
-    if (pindexLast == NULL)
+    if (pindexLast == nullptr)
         return bnTargetLimit.GetCompact(); // genesis block
 
     const CBlockIndex* pindexPrev = GetLastBlockIndex(pindexLast, fProofOfStake);
-    if (pindexPrev->pprev == NULL)
+    if (pindexPrev->pprev == nullptr)
         return bnTargetLimit.GetCompact(); // first block
     const CBlockIndex* pindexPrevPrev = GetLastBlockIndex(pindexPrev->pprev, fProofOfStake);
-    if (pindexPrevPrev->pprev == NULL)
+    if (pindexPrevPrev->pprev == nullptr)
         return bnTargetLimit.GetCompact(); // second block
-
 
 
     bool fFlashStake = false;
@@ -1140,21 +1149,19 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
 
     if (fProofOfStake)
     {
-        nTS = nTargetSpacing_Staking;
-
         if (IsFlashStake(nBlockTime))
         {
+            fFlashStake = true;
+            nTS = nTargetSpacing_FlashStaking;
             if (!IsFlashStake(pindexPrev->nTime))
                 fFlashFlip = true;
-            nTS = nTargetSpacing_FlashStaking;
-            fFlashStake = true;
-        } else {
+        }
+        else {
+            nTS = nTargetSpacing_Staking;
             if (IsFlashStake(pindexPrev->nTime))
                 fFlashFlip = true;
         }
     }
-
-
 
 
     // ppcoin: target change every block
@@ -1165,23 +1172,19 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
 
     if (fFlashFlip)
     {
-        if (fFlashStake)
-        {
-            const CBlockIndex* pPrev = GetLastBlockIndex2(pindexPrev, true);
-            if (pPrev == NULL)
-                return bnTargetLimit.GetCompact();
-            nActualSpacing = pPrev->GetBlockTime() - GetLastBlockIndex(pPrev, true)->GetBlockTime();
-            bnNew.SetCompact(pPrev->nBits);
-        }
-        else {
-            const CBlockIndex* pPrev = GetLastBlockIndex2(pindexPrev, false);
-            nActualSpacing = pPrev->GetBlockTime() - GetLastBlockIndex(pPrev, true)->GetBlockTime();
-            bnNew.SetCompact(pPrev->nBits);
-        }
-    } else {
+        // Replaces old version of nActualSpacing calculation for flip
+        // blocks as it was discovered to always resolve to 0.
+        const CBlockIndex* pPrev = GetLastBlockIndex2(pindexPrev, fFlashStake);
+        if (pPrev == nullptr)
+            return bnTargetLimit.GetCompact();
+        nActualSpacing = 0;
+        bnNew.SetCompact(pPrev->nBits);
+    }
+    else {
         bnNew.SetCompact(pindexPrev->nBits);
         nActualSpacing = pindexPrev->GetBlockTime() - pindexPrevPrev->GetBlockTime();
     }
+
 
     if (pindexPrev->nHeight < 315065)
     {
@@ -1199,6 +1202,76 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
 
     bnNew *= ((nInterval - 1) * (nTS) + nActualSpacing + nActualSpacing);
     bnNew /= ((nInterval + 1) * (nTS));
+
+    if (bnNew <= 0 || bnNew > bnTargetLimit)
+        bnNew = bnTargetLimit;
+
+    return bnNew.GetCompact();
+}
+
+unsigned int GetNextTargetRequiredV2(const CBlockIndex* pindexLast, bool fProofOfStake, unsigned int nBlockTime)
+{
+    CBigNum bnTargetLimit;
+    int64_t nActualSpacing;
+    int nTS;
+    CBigNum bnNew;
+
+    bool fFlashStake = false;
+
+    // Gets first previous block (PoW/PoS).
+    const CBlockIndex* pindexPrev = GetLastBlockIndex(pindexLast, fProofOfStake);
+
+    if (fProofOfStake) // PoS or FPoS block
+    {
+        if (IsFlashStake(nBlockTime)) {
+            fFlashStake = true;
+            bnTargetLimit = bnProofOfFlashStakeLimit;
+            nTS = nTargetSpacing_FlashStaking;
+        }
+        else {
+            bnTargetLimit = bnProofOfStakeLimit;
+            nTS = nTargetSpacing_Staking;
+        }
+
+        // Gets two previous same algorithm (PoS or FPoS) blocks.
+        const CBlockIndex* pPrevSameAlgo = GetLastBlockIndex2(pindexPrev, fFlashStake);
+        const CBlockIndex* pPrevPrevSameAlgo = GetLastBlockIndex2(pPrevSameAlgo->pprev, fFlashStake);
+
+        nActualSpacing = pPrevSameAlgo->GetBlockTime() - pPrevPrevSameAlgo->GetBlockTime();
+        bnNew.SetCompact(pPrevSameAlgo->nBits);
+    }
+    else // PoW block
+    {
+        bnTargetLimit = bnProofOfWorkLimit;
+        nTS = nTargetSpacing;
+
+        // Gets second PoW block.
+        const CBlockIndex* pindexPrevPrev = GetLastBlockIndex(pindexPrev->pprev, false);
+
+        nActualSpacing = pindexPrev->GetBlockTime() - pindexPrevPrev->GetBlockTime();
+        bnNew.SetCompact(pindexPrev->nBits);
+    }
+
+    // Makes sure that time spacing between consecutive
+    // PoS/FPoS periods is removed from nActualSpacing final value.
+    // Additionally slows down target adjustment in case of very large block spacing
+    // (higher than 1h) for all algorithms (PoW, PoS, FPoS).
+    nActualSpacing %= 3600;
+
+
+    // ppcoin: target change every block
+    // ppcoin: retarget with exponential moving toward target spacing
+    int64_t nInterval;
+
+    if (fFlashStake)
+        nInterval = nFlashStakeTargetTimespan / nTS;
+    else if (fProofOfStake)
+        nInterval = nStakeTargetTimespan / nTS;
+    else
+        nInterval = nTargetTimespan / nTS;
+
+    bnNew *= ((nInterval - 1) * nTS + nActualSpacing + nActualSpacing);
+    bnNew /= ((nInterval + 1) * nTS);
 
     if (bnNew <= 0 || bnNew > bnTargetLimit)
         bnNew = bnTargetLimit;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1238,6 +1238,11 @@ unsigned int GetNextTargetRequiredV2(const CBlockIndex* pindexLast, bool fProofO
         const CBlockIndex* pPrevPrevSameAlgo = GetLastBlockIndex2(pPrevSameAlgo->pprev, fFlashStake);
 
         nActualSpacing = pPrevSameAlgo->GetBlockTime() - pPrevPrevSameAlgo->GetBlockTime();
+        // Makes sure that time spacing between consecutive
+        // PoS/FPoS periods is removed from nActualSpacing final value.
+        // Additionally slows down target adjustment in case of very large
+        // block spacing (higher than 1h) for all PoS blocks.
+        nActualSpacing %= 3600;
         bnNew.SetCompact(pPrevSameAlgo->nBits);
     }
     else // PoW block
@@ -1251,12 +1256,6 @@ unsigned int GetNextTargetRequiredV2(const CBlockIndex* pindexLast, bool fProofO
         nActualSpacing = pindexPrev->GetBlockTime() - pindexPrevPrev->GetBlockTime();
         bnNew.SetCompact(pindexPrev->nBits);
     }
-
-    // Makes sure that time spacing between consecutive
-    // PoS/FPoS periods is removed from nActualSpacing final value.
-    // Additionally slows down target adjustment in case of very large block spacing
-    // (higher than 1h) for all algorithms (PoW, PoS, FPoS).
-    nActualSpacing %= 3600;
 
 
     // ppcoin: target change every block

--- a/src/main.h
+++ b/src/main.h
@@ -109,6 +109,8 @@ bool LoadExternalBlockFile(FILE* fileIn);
 
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
 unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfStake, unsigned int nBlockTime = 0);
+unsigned int GetNextTargetRequiredV1(const CBlockIndex* pindexLast, bool fProofOfStake, unsigned int nBlockTime = 0);
+unsigned int GetNextTargetRequiredV2(const CBlockIndex* pindexLast, bool fProofOfStake, unsigned int nBlockTime = 0);
 int64_t GetProofOfWorkReward(int nHeight, int64_t nFees);
 int64_t GetProofOfStakeReward(int64_t nCoinAge, int64_t nFees, int nHeight, unsigned int nTime);
 unsigned int ComputeMinWork(unsigned int nBase, int64_t nTime);


### PR DESCRIPTION
Fix GetNextTargetRequired function calculating new target value. For every second block after PoS<->FPoS flip nActualSpacing was calculated as a difference between FPoS and PoS blocks (instead of PoS and PoS or FPoS and FPoS) which could lead to too big / too small time difference and wrong difficulty values.