### PR TITLE
Disable time offset

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3209,8 +3209,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         pfrom->fClient = !(pfrom->nServices & NODE_NETWORK);
 
-        if (GetBoolArg("-synctime", true))
-            AddTimeData(pfrom->addr, nTime);
+        AddTimeData(pfrom->addr, nTime, GetBoolArg("-synctime", false));
 
         // Change version
         pfrom->PushMessage("verack");

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -191,7 +191,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Insufficient funds"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Warning: Please check that your computer's date and time are correct! "
-"Also high CPU usage on your device may cause delays in message processing and unintended time offset! "
 "If your clock is wrong Pinkcoin will not work properly."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Warning: This version is obsolete, upgrade required!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "WARNING: syncronized checkpoint violation detected, but skipped!"),

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -190,8 +190,9 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Insufficient funds"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Warning: Please check that your computer's date and time are correct! If "
-"your clock is wrong Pinkcoin will not work properly."),
+"Warning: Please check that your computer's date and time are correct! "
+"Also high CPU usage on your device may cause delays in message processing and unintended time offset! "
+"If your clock is wrong Pinkcoin will not work properly."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Warning: This version is obsolete, upgrade required!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "WARNING: syncronized checkpoint violation detected, but skipped!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Warning: Disk space is low!"),

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1200,12 +1200,15 @@ void CompareTimeWithPeers(const std::vector<int64_t>& vSorted)
             fDone = true;
             string strMessage = _(
                 "Warning: Please check that your computer's date and time are correct! "
-                "Also high CPU usage on your device may cause delays in message processing and unintended time offset! "
                 "If your clock is wrong Pinkcoin will not work properly."
             );
             strMiscWarning = strMessage;
             printf("*** %s\n", strMessage.c_str());
-            uiInterface.ThreadSafeMessageBox(strMessage+" ", string("Pinkcoin"), CClientUIInterface::OK | CClientUIInterface::ICON_EXCLAMATION);
+            uiInterface.ThreadSafeMessageBox(
+                strMessage+" ",
+                string("Pinkcoin"),
+                CClientUIInterface::OK | CClientUIInterface::ICON_EXCLAMATION
+            );
         }
     }
 }
@@ -1240,20 +1243,20 @@ void AddTimeData(const CNetAddr& ip, int64_t nTime, bool fSyncTime)
     // So we should hold off on fixing this and clean it up as part of
     // a timing cleanup that strengthens it in a number of other ways.
     //
-    if (vTimeOffsets.size() >= 5 && vTimeOffsets.size() % 2 == 1)
+    // No time offset adjustment. Just Compare node
+    // local time with peers and displays warning if offset it to big.
+    if (!fSyncTime)
+    {
+        if (vTimeOffsets.size() >= 5)
+            CompareTimeWithPeers(vTimeOffsets.sorted());
+    }
+    else if (vTimeOffsets.size() >= 5 && vTimeOffsets.size() % 2 == 1)
     {
         int64_t nMedian = vTimeOffsets.median();
         std::vector<int64_t> vSorted = vTimeOffsets.sorted();
 
-        // No time offset adjustment. Just Compare node
-        // local time with peers and displays warning if offset it to big.
-        if (!fSyncTime)
-        {
-            CompareTimeWithPeers(vSorted);
-            return;
-        }
         // Only let other nodes change our time by so much
-        else if (abs64(nMedian) < 30)
+        if (abs64(nMedian) < 30)
         {
             nTimeOffset = nMedian;
         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1184,7 +1184,7 @@ int64_t GetAdjustedTime()
     return GetTime() + GetTimeOffset();
 }
 
-void compareTimeWithPeers(const std::vector<int64_t>& vSorted)
+void CompareTimeWithPeers(const std::vector<int64_t>& vSorted)
 {
     static bool fDone;
     if (!fDone)
@@ -1249,7 +1249,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nTime, bool fSyncTime)
         // local time with peers and displays warning if offset it to big.
         if (!fSyncTime)
         {
-            compareTimeWithPeers(vSorted);
+            CompareTimeWithPeers(vSorted);
             return;
         }
         // Only let other nodes change our time by so much
@@ -1260,7 +1260,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nTime, bool fSyncTime)
         else
         {
             nTimeOffset = 0;
-            compareTimeWithPeers(vSorted);
+            CompareTimeWithPeers(vSorted);
         }
         if (fDebug) {
             BOOST_FOREACH(int64_t n, vSorted)

--- a/src/util.h
+++ b/src/util.h
@@ -210,7 +210,7 @@ int64_t GetAdjustedTime();
 int64_t GetTimeOffset();
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
-void compareTimeWithPeers(const std::vector<int64_t>& vSorted);
+void CompareTimeWithPeers(const std::vector<int64_t>& vSorted);
 void AddTimeData(const CNetAddr& ip, int64_t nTime, bool fSyncTime = false);
 void runCommand(std::string strCommand);
 

--- a/src/util.h
+++ b/src/util.h
@@ -210,7 +210,8 @@ int64_t GetAdjustedTime();
 int64_t GetTimeOffset();
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
-void AddTimeData(const CNetAddr& ip, int64_t nTime);
+void compareTimeWithPeers(const std::vector<int64_t>& vSorted);
+void AddTimeData(const CNetAddr& ip, int64_t nTime, bool fSyncTime = false);
 void runCommand(std::string strCommand);
 
 


### PR DESCRIPTION
Disable time offset for now to fix issues with unintended shift of it and forking issues. Fix is temporary and will be replaced with proper solution in the next update.