### PR TITLE
NTP Update

### DIFF
--- a/pinkcoin-qt.pro
+++ b/pinkcoin-qt.pro
@@ -329,7 +329,8 @@ HEADERS += src/qt/bitcoingui.h \
     src/qt/sendmessagesdialog.h \
     src/qt/sendmessagesentry.h \
     src/qt/plugins/mrichtexteditor/mrichtextedit.h \
-    src/qt/qvalidatedtextedit.h
+    src/qt/qvalidatedtextedit.h \
+    src/ntp.h
 
 SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/transactiontablemodel.cpp \
@@ -408,7 +409,8 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/scrypt-x86_64.S \
     src/scrypt.cpp \
     src/pbkdf2.cpp \
-    src/stealth.cpp
+    src/stealth.cpp\
+    src/ntp.cpp
 
 RESOURCES += \
     src/qt/bitcoin.qrc 
@@ -480,8 +482,7 @@ LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB
 LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
 # -lgdi32 has to happen after -lcrypto (see  #681)
 windows:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
-LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
-windows:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
+LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX -lboost_chrono$$BOOST_LIB_SUFFIX
 
 contains(RELEASE, 1) {
     !windows:!macx {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3177,6 +3177,14 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return false;
         }
 
+        if (fNTPSuccess && (nTime > (GetAdjustedTime() + 2) || nTime < (GetAdjustedTime() - 30)))
+        {
+            printf("partner %s does not have current time provided by NTP. "
+                   "Our time: %" PRIi64" Their time: %" PRIi64", disconnecting.", pfrom->addr.ToString().c_str(), GetAdjustedTime(), nTime);
+            pfrom->fDisconnect = true;
+            return false;
+        }
+
         if (pfrom->nVersion == 10300)
             pfrom->nVersion = 300;
         if (!vRecv.empty())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "db.h"
 #include "txdb.h"
 #include "net.h"
+#include "ntp.h"
 #include "init.h"
 #include "ui_interface.h"
 #include "kernel.h"
@@ -681,7 +682,7 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx,
             static CCriticalSection cs;
             static double dFreeCount;
             static int64_t nLastTime;
-            int64_t nNow = GetTime();
+            int64_t nNow = GetAdjustedTime();
 
             {
                 LOCK(cs);
@@ -1370,10 +1371,10 @@ bool IsInitialBlockDownload()
     if (pindexBest != pindexLastBest)
     {
         pindexLastBest = pindexBest;
-        nLastUpdate = GetTime();
+        nLastUpdate = GetAdjustedTime();
     }
-    return (GetTime() - nLastUpdate < 15 &&
-            pindexBest->GetBlockTime() < GetTime() - 8 * 60 * 60);
+    return (GetAdjustedTime() - nLastUpdate < 15 &&
+            pindexBest->GetBlockTime() < GetAdjustedTime() - 8 * 60 * 60);
 }
 
 void static InvalidChainFound(CBlockIndex* pindexNew)
@@ -2030,7 +2031,7 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
     pblockindexFBBHLast = NULL;
     nBestHeight = pindexBest->nHeight;
     nBestChainTrust = pindexNew->nChainTrust;
-    nTimeBestReceived = GetTime();
+    nTimeBestReceived = GetAdjustedTime();
     nTransactionsUpdated++;
 
     uint256 nBestBlockTrust = pindexBest->nHeight != 0 ? (pindexBest->nChainTrust - pindexBest->pprev->nChainTrust) : pindexBest->nChainTrust;
@@ -3209,7 +3210,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         pfrom->fClient = !(pfrom->nServices & NODE_NETWORK);
 
-        AddTimeData(pfrom->addr, nTime, GetBoolArg("-synctime", false));
+        if (!GetBoolArg("-usentp", true) || !fNTPSuccess)
+        {
+            AddTimeData(pfrom->addr, nTime, GetBoolArg("-synctime", false));
+        }
 
         // Change version
         pfrom->PushMessage("verack");
@@ -3329,7 +3333,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     if (hashSalt == 0)
                         hashSalt = GetRandHash();
                     uint64_t hashAddr = addr.GetHash();
-                    uint256 hashRand = hashSalt ^ (hashAddr<<32) ^ ((GetTime()+hashAddr)/(24*60*60));
+                    uint256 hashRand = hashSalt ^ (hashAddr<<32) ^ ((GetAdjustedTime()+hashAddr)/(24*60*60));
                     hashRand = Hash(BEGIN(hashRand), END(hashRand));
                     multimap<uint256, CNode*> mapMix;
                     BOOST_FOREACH(CNode* pnode, vNodes)
@@ -3670,7 +3674,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return true;
         }
         // Don't return addresses older than nCutOff timestamp
-        int64_t nCutOff = GetTime() - (nNodeLifespan * 24 * 60 * 60);
+        int64_t nCutOff = GetAdjustedTime() - (nNodeLifespan * 24 * 60 * 60);
         pfrom->vAddrToSend.clear();
         vector<CAddress> vAddr = addrman.GetAddr();
         BOOST_FOREACH(const CAddress &addr, vAddr)
@@ -3979,7 +3983,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
 
         // Address refresh broadcast
         static int64_t nLastRebroadcast;
-        if (!IsInitialBlockDownload() && (GetTime() - nLastRebroadcast > 24 * 60 * 60))
+        if (!IsInitialBlockDownload() && (GetAdjustedTime() - nLastRebroadcast > 24 * 60 * 60))
         {
             {
                 LOCK(cs_vNodes);
@@ -3998,7 +4002,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                     }
                 }
             }
-            nLastRebroadcast = GetTime();
+            nLastRebroadcast = GetAdjustedTime();
         }
 
         //
@@ -4090,7 +4094,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         // Message: getdata
         //
         vector<CInv> vGetData;
-        int64_t nNow = GetTime() * 1000000;
+        int64_t nNow = GetAdjustedTime() * 1000000;
         CTxDB txdb("r");
         while (!pto->mapAskFor.empty() && (*pto->mapAskFor.begin()).first <= nNow)
         {

--- a/src/main.h
+++ b/src/main.h
@@ -84,6 +84,7 @@ extern int64_t nSplitThreshold;
 extern int64_t nMinimumInputValue;
 extern int64_t nMinimumStakeValue;
 extern bool fUseFastIndex;
+extern bool fNTPSuccess;
 extern unsigned int nDerivationMethodIndex;
 
 // Minimum disk space required - used in CheckDiskSpace()
@@ -643,7 +644,7 @@ public:
         str += strprintf("(hash=%s, nTime=%d, currentTime=%d, ver=%d, vin.size=%" PRIszu ", vout.size=%" PRIszu ", nLockTime=%d)\n",
             GetHash().ToString().substr(0,10).c_str(),
             nTime,
-            (unsigned int)GetTime(),
+            (unsigned int)GetAdjustedTime(),
             nVersion,
             vin.size(),
             vout.size(),

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -60,6 +60,7 @@ OBJS= \
     obj/main.o \
     obj/miner.o \
     obj/net.o \
+    obj/ntp.o \
     obj/protocol.o \
     obj/bitcoinrpc.o \
     obj/rpcdump.o \

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -31,6 +31,7 @@ LIBS += \
  $(DEPSDIR)/lib/libboost_filesystem-mt.a \
  $(DEPSDIR)/lib/libboost_program_options-mt.a \
  $(DEPSDIR)/lib/libboost_thread-mt.a \
+ $(DEPSDIR)/lib/libboost_chrono-mt.a \
  $(DEPSDIR)/lib/libssl.a \
  $(DEPSDIR)/lib/libcrypto.a \
  $(DEPSDIR)/lib/libz.a
@@ -75,6 +76,7 @@ OBJS= \
     obj/miner.o \
     obj/main.o \
     obj/net.o \
+    obj/ntp.o \
     obj/protocol.o \
     obj/bitcoinrpc.o \
     obj/rpcdump.o \

--- a/src/makefile.pi
+++ b/src/makefile.pi
@@ -10,6 +10,7 @@ LIBS= \
  -l boost_filesystem \
  -l boost_program_options \
  -l boost_thread \
+ -l boost_chrono \
  -l db_cxx \
  -l ssl \
  -l crypto
@@ -109,6 +110,7 @@ OBJS= \
 	obj/miner.o \
 	obj/main.o \
 	obj/net.o \
+    obj/ntp.o \
 	obj/protocol.o \
 	obj/bitcoinrpc.o \
 	obj/rpcdump.o \

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -31,6 +31,7 @@ LIBS += \
    -l boost_filesystem$(BOOST_LIB_SUFFIX) \
    -l boost_program_options$(BOOST_LIB_SUFFIX) \
    -l boost_thread$(BOOST_LIB_SUFFIX) \
+   -l boost_chrono$(BOOST_LIB_SUFFIX) \
    -l db_cxx$(BDB_LIB_SUFFIX) \
    -l ssl \
    -l crypto
@@ -115,6 +116,7 @@ OBJS= \
     obj/miner.o \
     obj/main.o \
     obj/net.o \
+    obj/ntp.o \
     obj/protocol.o \
     obj/bitcoinrpc.o \
     obj/rpcdump.o \

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -498,7 +498,7 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest)
             vNodes.push_back(pnode);
         }
 
-        pnode->nTimeConnected = GetTime();
+        pnode->nTimeConnected = GetAdjustedTime();
         return pnode;
     }
     else
@@ -531,7 +531,7 @@ void CNode::Cleanup()
 void CNode::PushVersion()
 {
     /// when NTP implemented, change to just nTime = GetAdjustedTime()
-    int64_t nTime = (fInbound ? GetAdjustedTime() : GetTime());
+    int64_t nTime = GetAdjustedTime();
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService("0.0.0.0",0)));
     CAddress addrMe = GetLocalAddress(&addr);
     RAND_bytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
@@ -561,7 +561,7 @@ bool CNode::IsBanned(CNetAddr ip)
         if (i != setBanned.end())
         {
             int64_t t = (*i).second;
-            if (GetTime() < t)
+            if (GetAdjustedTime() < t)
                 fResult = true;
         }
     }
@@ -579,7 +579,7 @@ bool CNode::Misbehaving(int howmuch)
     nMisbehavior += howmuch;
     if (nMisbehavior >= GetArg("-banscore", 100))
     {
-        int64_t banTime = GetTime()+GetArg("-bantime", 60*60*24);  // Default 24-hour ban
+        int64_t banTime = GetAdjustedTime()+GetArg("-bantime", 60*60*24);  // Default 24-hour ban
         printf("Misbehaving: %s (%d -> %d) DISCONNECTING\n", addr.ToString().c_str(), nMisbehavior-howmuch, nMisbehavior);
         {
             LOCK(cs_setBanned);
@@ -744,7 +744,7 @@ void SocketSendData(CNode *pnode)
         assert(data.size() > pnode->nSendOffset);
         int nBytes = send(pnode->hSocket, &data[pnode->nSendOffset], data.size() - pnode->nSendOffset, MSG_NOSIGNAL | MSG_DONTWAIT);
         if (nBytes > 0) {
-            pnode->nLastSend = GetTime();
+            pnode->nLastSend = GetAdjustedTime();
             pnode->nSendOffset += nBytes;
             
             pnode->nSendBytes += nBytes;
@@ -1027,7 +1027,7 @@ void ThreadSocketHandler2(void* parg)
                         {
                             if (!pnode->ReceiveMsgBytes(pchBuf, nBytes))
                                 pnode->CloseSocketDisconnect();
-                            pnode->nLastRecv = GetTime();
+                            pnode->nLastRecv = GetAdjustedTime();
                             pnode->nRecvBytes += nBytes;
                             pnode->RecordBytesRecv(nBytes);
                         }
@@ -1068,7 +1068,7 @@ void ThreadSocketHandler2(void* parg)
             //
             // Inactivity checking
             //
-            int64_t nTime = GetTime();
+            int64_t nTime = GetAdjustedTime();
             if (nTime - pnode->nTimeConnected > 60)
             {
                 if (pnode->nLastRecv == 0 || pnode->nLastSend == 0)
@@ -1330,7 +1330,7 @@ void ThreadDNSAddressSeed2(void* parg)
                 {
                     int nOneDay = 24*3600;
                     CAddress addr = CAddress(CService(ip, GetDefaultPort()));
-                    addr.nTime = GetTime() - 3*nOneDay - GetRand(4*nOneDay); // use a random age between 3 and 7 days old
+                    addr.nTime = GetAdjustedTime() - 3*nOneDay - GetRand(4*nOneDay); // use a random age between 3 and 7 days old
                     vAdd.push_back(addr);
                     found++;
                 }
@@ -1483,7 +1483,7 @@ void ThreadOpenConnections2(void* parg)
     }
 
     // Initiate network connections
-    int64_t nStart = GetTime();
+    int64_t nStart = GetAdjustedTime();
     while (true)
     {
         ProcessOneShot();
@@ -1502,7 +1502,7 @@ void ThreadOpenConnections2(void* parg)
             return;
 
         // Add seed nodes if IRC isn't working
-        if (addrman.size()==0 && (GetTime() - nStart > 60) && !fTestNet)
+        if (addrman.size()==0 && (GetAdjustedTime() - nStart > 60) && !fTestNet)
         {
             std::vector<CAddress> vAdd;
             for (unsigned int i = 0; i < ARRAYLEN(pnSeed); i++)
@@ -1515,7 +1515,7 @@ void ThreadOpenConnections2(void* parg)
                 struct in_addr ip;
                 memcpy(&ip, &pnSeed[i], sizeof(ip));
                 CAddress addr(CService(ip, GetDefaultPort()));
-                addr.nTime = GetTime()-GetRand(nOneWeek)-nOneWeek;
+                addr.nTime = GetAdjustedTime()-GetRand(nOneWeek)-nOneWeek;
                 vAdd.push_back(addr);
             }
             addrman.Add(vAdd, CNetAddr("127.0.0.1"));
@@ -2036,7 +2036,7 @@ bool StopNode()
     printf("StopNode()\n");
     fShutdown = true;
     nTransactionsUpdated++;
-    int64_t nStart = GetTime();
+    int64_t nStart = GetAdjustedTime();
     if (semOutbound)
         for (int i=0; i<MAX_OUTBOUND_CONNECTIONS; i++)
             semOutbound->post();
@@ -2047,7 +2047,7 @@ bool StopNode()
             nThreadsRunning += vnThreadsRunning[n];
         if (nThreadsRunning == 0)
             break;
-        if (GetTime() - nStart > 20)
+        if (GetAdjustedTime() - nStart > 20)
             break;
         MilliSleep(20);
     } while(true);
@@ -2108,7 +2108,7 @@ void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataSt
     {
         LOCK(cs_mapRelay);
         // Expire old relay messages
-        while (!vRelayExpiration.empty() && vRelayExpiration.front().first < GetTime())
+        while (!vRelayExpiration.empty() && vRelayExpiration.front().first < GetAdjustedTime())
         {
             mapRelay.erase(vRelayExpiration.front().second);
             vRelayExpiration.pop_front();
@@ -2116,7 +2116,7 @@ void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataSt
 
         // Save original serialized message so newer versions are preserved
         mapRelay.insert(std::make_pair(inv, ss));
-        vRelayExpiration.push_back(std::make_pair(GetTime() + 15 * 60, inv));
+        vRelayExpiration.push_back(std::make_pair(GetAdjustedTime() + 15 * 60, inv));
     }
 
     RelayInventory(inv);

--- a/src/net.h
+++ b/src/net.h
@@ -288,8 +288,8 @@ public:
         nLastRecv = 0;
         nSendBytes = 0;
         nRecvBytes = 0;
-        nLastSendEmpty = GetTime();
-        nTimeConnected = GetTime();
+        nLastSendEmpty = GetAdjustedTime();
+        nTimeConnected = GetAdjustedTime();
         addr = addrIn;
         addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
         nVersion = 0;
@@ -422,7 +422,7 @@ public:
             printf("askfor %s   %" PRId64 " (%s)\n", inv.ToString().c_str(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000).c_str());
 
         // Make sure not to reuse time indexes to keep things in the same order
-        int64_t nNow = (GetTime() - 1) * 1000000;
+        int64_t nNow = (GetAdjustedTime() - 1) * 1000000;
         static int64_t nLastTime;
         ++nLastTime;
         nNow = std::max(nNow, nLastTime);

--- a/src/ntp.cpp
+++ b/src/ntp.cpp
@@ -179,7 +179,7 @@ void *threadGetNTPTime(int nServer, const string strPool, uint64_t startMicros)
     // User set :// or tried to use a port (org:###)
     // or is trying to use something other than ntp.org.
     // Drop whatever they set and just use the default.
-    if (strAddress.find(":") != std::string::npos || strAddress.find("pool.ntp.org") == std::string::npos)
+    if (strAddress == "" || strAddress.find(":") != std::string::npos || strAddress.find("pool.ntp.org") == std::string::npos)
         strAddress = "pool.ntp.org";
 
     // Prepend pool server number.
@@ -294,7 +294,7 @@ bool SetNTPOffset(const string &strPool)
 
 }
 
-void *threadNTPUpdate(const string strNTPool)
+void *threadNTPUpdate(const string &strNTPool)
 {
 
     static int nRefreshTime = 0;

--- a/src/ntp.cpp
+++ b/src/ntp.cpp
@@ -158,7 +158,7 @@ bool GetNTPTime(const char *addrConnect, uint64_t& timeRet)
     ntpMicros += ((double)tMicros / std::numeric_limits<uint32_t>::max()) * 1000000;
 
     // Split the difference between when we requested the time
-    // and when we go it to account for the network round trip.
+    // and when we got it to account for the network round trip.
     diffMicros = (endMicros - startMicros) / 2;
 
     // Add the difference to our time so we can better estimate
@@ -172,17 +172,18 @@ bool GetNTPTime(const char *addrConnect, uint64_t& timeRet)
 static uint64_t ntpTime[4];
 void *threadGetNTPTime(int nServer, const string strPool, uint64_t startMicros)
 {
+    std::string strAddress = strPool;
     if (nServer > 3)
         return nullptr;
 
     // User set :// or tried to use a port (org:###)
     // or is trying to use something other than ntp.org.
     // Drop whatever they set and just use the default.
-    if (strPool.find(":") != std::string::npos || strPool.find("pool.ntp.org") == std::string::npos)
-        strPool = "pool.ntp.org";
+    if (strAddress.find(":") != std::string::npos || strAddress.find("pool.ntp.org") == std::string::npos)
+        strAddress = "pool.ntp.org";
 
     // Prepend pool server number.
-    string strAddress = to_string(nServer) + "." + strPool;
+    strAddress = to_string(nServer) + "." + strAddress;
 
     uint64_t myTime = 0;
     if (GetNTPTime(strAddress.c_str(), myTime))
@@ -249,7 +250,7 @@ bool SetNTPOffset(const string &strPool)
 
         for (int i = 0; i < 4; i++)
         {
-            // Make sure we actually got the time. NTP servers that responde but aren't able
+            // Make sure we actually got the time. NTP servers that respond but aren't able
             // to give us an accurate time as requested instead send us the uint32 max.
             // We tolerate 10 seconds here to accomodate our internal adjustments.
             if (ntpTime[i] > 0 && abs((int64_t)(ntpTime[i] / 1000000) + (int64_t)nNTPUnix - (int64_t)std::numeric_limits<uint32_t>::max()) > 10)
@@ -335,7 +336,7 @@ void *threadNTPUpdate(const string strNTPool)
             nRefreshTime = (nRefreshTime < 3600) ? nRefreshTime + 400 : 3600;
         }
 
-        // Update our
+        // Update our Time Tracker.
         tTrack = tNow;
 
 

--- a/src/ntp.cpp
+++ b/src/ntp.cpp
@@ -1,0 +1,369 @@
+#include <iostream>
+#include <vector>
+
+#include <unistd.h>
+#include <string.h>
+#include <time.h>
+
+#include <chrono>
+#include <thread>
+
+#include "util.h"
+#include "ntp.h"
+
+
+// #include "ntp.h"
+
+
+// This is here to help us know what bytes to pull for what with our bTimeReq[48]
+/*
+  uint8_t li_vn_mode;      // Eight bits. li, vn, and mode.
+                           // li.   Two bits.   Leap indicator.
+                           // vn.   Three bits. Version number of the protocol.
+                           // mode. Three bits. Client will pick mode 3 for client.
+
+  uint8_t stratum;         // Eight bits. Stratum level of the local clock.
+  uint8_t poll;            // Eight bits. Maximum interval between successive messages.
+  uint8_t precision;       // Eight bits. Precision of the local clock.
+
+  uint32_t rootDelay;      // 32 bits. Total round trip delay time.
+  uint32_t rootDispersion; // 32 bits. Max error aloud from primary clock source.
+  uint32_t refId;          // 32 bits. Reference clock identifier.
+
+  uint32_t refTm_s;        // 32 bits. Reference time-stamp seconds.
+  uint32_t refTm_f;        // 32 bits. Reference time-stamp fraction of a second.
+
+  uint32_t origTm_s;       // 32 bits. Originate time-stamp seconds.
+  uint32_t origTm_f;       // 32 bits. Originate time-stamp fraction of a second.
+
+  uint32_t rxTm_s;         // 32 bits. Received time-stamp seconds.
+  uint32_t rxTm_f;         // 32 bits. Received time-stamp fraction of a second.
+
+  uint32_t txTm_s;         // 32 bits and the most important field the client cares about. Transmit time-stamp seconds.
+  uint32_t txTm_f;         // 32 bits. Transmit time-stamp fraction of a second.
+
+  48 bits total, hence bTimeReq[48]
+*/
+
+using namespace std;
+static uint64_t nNTPUnix = 2208988800ull;
+
+bool GetNTPTime(const char *addrConnect, uint64_t& timeRet)
+{
+
+    uint64_t startMicros = 0;
+    uint64_t endMicros = 0;
+    uint64_t diffMicros = 0;
+
+    // We're doing a lot of this by hand instead of using our classes in netbase.cpp
+    // because that hasn't been set up for UDP requests. This can be moved into netbase
+    // should we ever need UDP support for any other reason, but for now this is fine.
+
+    // Gotta use BigEndian for networks. NTP uses UDP port 123.
+    int udpPort = htons(123);
+
+    // Standard UDP socket.
+    int socketNTP = socket( AF_INET , SOCK_DGRAM, IPPROTO_UDP);
+    if (socketNTP < 0)
+        return false;
+
+    struct sockaddr_in sockAddr;
+    struct hostent *hNTPServ;
+
+    // Zero out our socket address.
+    memset(&sockAddr, 0, sizeof(sockAddr));
+
+    // Get our host from DNS.
+    hNTPServ = gethostbyname(addrConnect);
+
+    if (hNTPServ == nullptr)
+        return false;
+
+    // Set our connection information.
+    sockAddr.sin_family = AF_INET;
+    memcpy(&sockAddr.sin_addr.s_addr, hNTPServ->h_addr_list[0], hNTPServ->h_length);
+    sockAddr.sin_port = udpPort;
+
+
+    // Set our timeout to 2 seconds.
+#ifdef WIN32
+    DWORD timeout = 2000;
+    setsockopt(socketNTP, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout, sizeof(timeout));
+#else
+    struct timeval tv;
+    tv.tv_sec = 2;
+    tv.tv_usec = 0;
+    setsockopt(socketNTP, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof(tv));
+#endif
+
+    // Connect to NTP
+    if (connect(socketNTP, (struct sockaddr*) &sockAddr, sizeof(sockAddr)) < 0)
+        return false;
+
+    // Our buffer for our request from NTP. See note above for its structure.
+    // Note: we're not bothering with the struct. We're just grabbing what we need.
+    char bTimeReq[48];
+
+    // Clear it.
+    memset(&bTimeReq, 0, 48);
+
+    // Set the first byte so NTP knows what to send us.
+    // Leap Indicator = 0
+    // Version = 3
+    // Mode 3
+    bTimeReq[0] = 0x1b;
+
+    // Time we send our request
+    startMicros = boost::chrono::duration_cast<boost::chrono::microseconds>(boost::chrono::system_clock::now().time_since_epoch()).count();
+    int n = send(socketNTP, (char*)&bTimeReq, 48, 0);
+
+    if (n < 0)
+        return false;
+
+
+    n = recv(socketNTP, (char*)&bTimeReq, 48, 0);
+    // Time we got it
+    endMicros = boost::chrono::duration_cast<boost::chrono::microseconds>(boost::chrono::system_clock::now().time_since_epoch()).count();
+
+    if (n < 0)
+        return false;
+
+    uint32_t tSeconds = 0;
+    uint32_t tMicros = 0;
+
+    // Grab the time in seconds &[40] (Note: NTP is from Jan 1, 1900)
+    // Grab the fraction of second &[48] (Note: Fraction is N/UINT32(MAX))
+
+    memcpy(&tSeconds, &bTimeReq[40], 4);
+    memcpy(&tMicros, &bTimeReq[44], 4);
+
+    // Convert back to LittleEndian (everything Pink runs on atm uses LE)
+    tSeconds = ntohl(tSeconds);
+    tMicros = ntohl(tMicros);
+
+    // Subtract the UNIX Epoch from NTP Time (Jan 1, 1970 - Jan 1, 1900)
+    int64_t nEpoch = tSeconds - nNTPUnix;
+
+    if (nEpoch < 0)
+        nEpoch += std::numeric_limits<uint32_t>::max(); // NTP Rolled over int32 limit. Happens in Y2036.
+
+    // There is no reason this should *still* be < 0;
+    if (nEpoch < 0)
+        return false;
+
+    // Get our NTP time down to the microsecond.
+    // We have to convert NTP fractional time to Micros.
+    uint64_t ntpMicros = 0;
+    ntpMicros = (nEpoch * 1000000);
+    ntpMicros += ((double)tMicros / std::numeric_limits<uint32_t>::max()) * 1000000;
+
+    // Split the difference between when we requested the time
+    // and when we go it to account for the network round trip.
+    diffMicros = (endMicros - startMicros) / 2;
+
+    // Add the difference to our time so we can better estimate
+    // the time when we actually received it from NTP.
+    timeRet = (ntpMicros + diffMicros);
+
+    return true;
+
+}
+
+static uint64_t ntpTime[4];
+void *threadGetNTPTime(int nServer, const string strPool, uint64_t startMicros)
+{
+    if (nServer > 3)
+        return nullptr;
+
+    // User set :// or tried to use a port (org:###)
+    // or is trying to use something other than ntp.org.
+    // Drop whatever they set and just use the default.
+    if (strPool.find(":") != std::string::npos || strPool.find("pool.ntp.org") == std::string::npos)
+        strPool = "pool.ntp.org";
+
+    // Prepend pool server number.
+    string strAddress = to_string(nServer) + "." + strPool;
+
+    uint64_t myTime = 0;
+    if (GetNTPTime(strAddress.c_str(), myTime))
+    {
+        uint64_t nowMicros = boost::chrono::duration_cast<boost::chrono::microseconds>(boost::chrono::system_clock::now().time_since_epoch()).count();
+
+        // Subtract how long it took our thread to get the time.
+        myTime -= (nowMicros - startMicros);
+    }
+
+    ntpTime[nServer] = myTime;
+
+    return nullptr;
+}
+
+bool SetNTPOffset(const string &strPool)
+{
+    int nWait = 0;
+    static int tCount = 0;
+
+    uint64_t nowMicros = 0;
+    uint64_t avMicros;
+    int64_t nTimeOffset = 0;
+
+    vector<uint64_t> ntpMicros;
+
+    while (tCount < 4)
+    {
+        // Start with a fresh vector to hold our NTP Times
+        ntpMicros.clear();
+        avMicros = 0;
+
+        // We didn't get what we needed last time, so we're going to wait longer this time.
+        nWait++;
+
+        // If we don't have 4 good times after 4 iterations and waiting
+        // 2 seconds for a response on our last try then we give up.
+        if (nWait == 5)
+            return false;
+
+        for (int i = 0; i < 4; i++)
+            ntpTime[i] = 0;
+
+        // Let our threads know when we're starting from so they can give
+        // us times that are consistent with what we need.
+        nowMicros = boost::chrono::duration_cast<boost::chrono::microseconds>(boost::chrono::system_clock::now().time_since_epoch()).count();
+
+        // Any regional ntp pool can be used. But we prepend the number for NTP's randomized selection.
+        // By default we use pool.ntp.org - which generally selects pools that are appropriate for your ip.
+        // https://www.ntppool.org/en/use.html
+        // https://www.pool.ntp.org/zone/@
+        boost::thread nGet1(threadGetNTPTime, 0, strPool, nowMicros);
+        boost::thread nGet2(threadGetNTPTime, 1, strPool, nowMicros);
+        boost::thread nGet3(threadGetNTPTime, 2, strPool, nowMicros);
+        boost::thread nGet4(threadGetNTPTime, 3, strPool, nowMicros);
+
+        // Ideally we want times from NTP servers that can respond to us in < 500ms.
+        // We'll wait longer if we don't get what we need.
+        boost::this_thread::sleep_for(boost::chrono::milliseconds(500 * nWait));
+
+        // Get this now so we know exactly when we woke up again.
+        // Helps us get an accurate offset.
+        nowMicros = boost::chrono::duration_cast<boost::chrono::microseconds>(boost::chrono::system_clock::now().time_since_epoch()).count();
+
+        for (int i = 0; i < 4; i++)
+        {
+            // Make sure we actually got the time. NTP servers that responde but aren't able
+            // to give us an accurate time as requested instead send us the uint32 max.
+            // We tolerate 10 seconds here to accomodate our internal adjustments.
+            if (ntpTime[i] > 0 && abs((int64_t)(ntpTime[i] / 1000000) + (int64_t)nNTPUnix - (int64_t)std::numeric_limits<uint32_t>::max()) > 10)
+            {
+                // Account for our wait time.
+                ntpTime[i] += (500000 * nWait);
+                ntpMicros.push_back(ntpTime[i]);
+            }
+        }
+
+        // Add it up.
+        for (vector<uint64_t>::iterator it = ntpMicros.begin(); it != ntpMicros.end(); it++)
+             avMicros += *it;
+
+        // Average of what we got.
+        avMicros /= ntpMicros.size();
+
+        // Set our offset based on the difference and maintain an average.
+        nTimeOffset += (avMicros - nowMicros);
+        if (nWait > 1)
+            nTimeOffset /= 2;
+
+        // Add these to our successful NTP Request count.
+        tCount += ntpMicros.size();
+
+        // Clear up our threads
+        nGet1.join();
+        nGet2.join();
+        nGet3.join();
+        nGet4.join();
+    }
+
+    tCount = 0;
+
+    // nTimeOffset precision is in seconds, so convert from Micros.
+    nTimeOffset /= 1000000;
+
+    SetTimeOffset(nTimeOffset);
+
+    return true;
+
+}
+
+void *threadNTPUpdate(const string strNTPool)
+{
+
+    static int nRefreshTime = 0;
+    static int nFailCount = 0;
+
+    // If SetNTPOffset fails, we fall back on local/peer time, depending on
+    // user settings. What we're using is visible from the rpc command 'getinfo'
+    fNTPSuccess = SetNTPOffset(strNTPool);
+
+    // We use steady_clock here so we can be completely agnostic about the system
+    // time while we sleep. Protects user against a local clock manipulation attack
+    // and allows us to adjust our offset internally if the system time does change.
+    std::this_thread::sleep_for(std::chrono::steady_clock::duration(1000000000));
+
+    // Time Tracker tTrack helps us monitor for system clock changes each second.
+    uint64_t tTrack = GetAdjustedTime();
+
+    while (!fShutdown)
+    {
+        std::this_thread::sleep_for(std::chrono::steady_clock::duration(1000000000));
+
+        nRefreshTime++;
+
+        uint64_t tNow = GetAdjustedTime();
+
+        // Our clock changed in the last second.
+        if (abs((int64_t)tNow - ((int64_t)tTrack + 1)) > 1)
+        {
+            // We'll do this internally so we don't have to bug NTP
+            int64_t nOffset = GetTimeOffset();
+            nOffset += ((int64_t)tTrack + 1) - (int64_t)tNow;
+            SetTimeOffset(nOffset);
+
+            // Update tNow directly instead of from GetTimeOffset
+            // in case the system time changes since we set it.
+            tNow += ((int64_t)tTrack + 1) - (int64_t)tNow;
+
+            // Update our refresh time sooner from NTP though, just in case
+            nRefreshTime = (nRefreshTime < 3600) ? nRefreshTime + 400 : 3600;
+        }
+
+        // Update our
+        tTrack = tNow;
+
+
+        // Update against NTP every hour.
+        if (nRefreshTime == 3600)
+        {
+            nRefreshTime = 0;
+
+            // Only set fNTPSuccess to false after 24 hours of
+            // not having a successful update from NTP.
+            if (!SetNTPOffset(strNTPool))
+            {
+                nFailCount++;
+            } else {
+                fNTPSuccess = true;
+                nFailCount = 0;
+            }
+
+            if (nFailCount > 23)
+                fNTPSuccess = false;
+
+            // Start our next loop with a fresh tTrack;
+            tTrack = GetAdjustedTime();
+
+        }
+
+    }
+
+    return nullptr;
+}
+

--- a/src/ntp.h
+++ b/src/ntp.h
@@ -1,0 +1,9 @@
+#ifndef NTP_H
+#define NTP_H
+#include <string>
+
+extern bool fNTPSuccess;
+bool SetNTPOffset(const std::string &strPool = "pool.ntp.org");
+void *threadNTPUpdate(const std::string strNTPool = "");
+
+#endif // NTP_H

--- a/src/ntp.h
+++ b/src/ntp.h
@@ -3,7 +3,7 @@
 #include <string>
 
 extern bool fNTPSuccess;
-bool SetNTPOffset(const std::string &strPool = "pool.ntp.org");
-void *threadNTPUpdate(const std::string strNTPool = "");
+bool SetNTPOffset(const std::string &strPool);
+void *threadNTPUpdate(const std::string &strNTPool);
 
 #endif // NTP_H

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -11,7 +11,7 @@
 #include <QDateTime>
 #include <QTimer>
 
-static const int64_t nClientStartupTime = GetTime();
+static const int64_t nClientStartupTime = GetAdjustedTime();
 
 ClientModel::ClientModel(OptionsModel *optionsModel, QObject *parent) :
     QObject(parent), optionsModel(optionsModel),

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -230,11 +230,11 @@ void CoinControlDialog::customSelectCoins()
 					
 				//Coin Weight
 				uint64_t nTxWeight = 0;
-                double nTimeWeight = min(GetTime() - out.tx->GetTxTime() - nStakeMinAge, (int64_t)nStakeMaxAge) / 86400;
+                double nTimeWeight = min(GetAdjustedTime() - out.tx->GetTxTime() - nStakeMinAge, (int64_t)nStakeMaxAge) / 86400;
                 nTxWeight = dCoinAmount / COIN * nTimeWeight;
 					
 				//Age
-				double dAge = (GetTime() - out.tx->GetTxTime()) / (double)(1440 * 60);
+                double dAge = (GetAdjustedTime() - out.tx->GetTxTime()) / (double)(1440 * 60);
 			
 				COutPoint outpt(txhash, out.i);
 				
@@ -768,7 +768,7 @@ void CoinControlDialog::updateView()
 			
 			//Coin Weight
             int64_t nAmount = out.tx->vout[out.i].nValue;
-            double nTimeWeight = min(GetTime() - out.tx->GetTxTime() - nStakeMinAge, (int64_t)nStakeMaxAge) / 86400;
+            double nTimeWeight = min(GetAdjustedTime() - out.tx->GetTxTime() - nStakeMinAge, (int64_t)nStakeMaxAge) / 86400;
             nTxWeight = nAmount / COIN * nTimeWeight;
 			nTxWeightSum += nTxWeight;
             
@@ -840,7 +840,7 @@ void CoinControlDialog::updateView()
             itemOutput->setText(COLUMN_WEIGHT, strPad(QString::number((uint64_t)nTxWeight),8," "));
 			
 			// Age
-			uint64_t nAge = GetTime() - out.tx->GetTxTime();
+            uint64_t nAge = GetAdjustedTime() - out.tx->GetTxTime();
 			double age  = (double)nAge/60/60/24;
 			itemOutput->setText(COLUMN_AGE, QString::number(age, 'f', 2));
 			itemOutput->setText(COLUMN_AGE_int64_t, strPad(QString::number(nAge), 15, " "));

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -298,7 +298,7 @@ Value dumpwallet(const Array& params, bool fHelp)
 
     // produce output
     file << strprintf("# Wallet dump created by Pinkcoin %s (%s)\n", CLIENT_BUILD.c_str(), CLIENT_DATE.c_str());
-    file << strprintf("# * Created on %s\n", EncodeDumpTime(GetTime()).c_str());
+    file << strprintf("# * Created on %s\n", EncodeDumpTime(GetAdjustedTime()).c_str());
     file << strprintf("# * Best block at time of backup was %i (%s),\n", nBestHeight, hashBestChain.ToString().c_str());
     file << strprintf("#   mined on %s\n", EncodeDumpTime(pindexBest->nTime).c_str());
     file << "\n";

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -141,7 +141,7 @@ Value getworkex(const Array& params, bool fHelp)
         static int64_t nStart;
         static CBlock* pblock;
         if (pindexPrev != pindexBest ||
-            (nTransactionsUpdated != nTransactionsUpdatedLast && GetTime() - nStart > 60))
+            (nTransactionsUpdated != nTransactionsUpdatedLast && GetAdjustedTime() - nStart > 60))
         {
             if (pindexPrev != pindexBest)
             {
@@ -153,7 +153,7 @@ Value getworkex(const Array& params, bool fHelp)
             }
             nTransactionsUpdatedLast = nTransactionsUpdated;
             pindexPrev = pindexBest;
-            nStart = GetTime();
+            nStart = GetAdjustedTime();
 
             // Create new block
             pblock = CreateNewBlock(pwalletMain);
@@ -272,7 +272,7 @@ Value getwork(const Array& params, bool fHelp)
         static int64_t nStart;
         static CBlock* pblock;
         if (pindexPrev != pindexBest ||
-            (nTransactionsUpdated != nTransactionsUpdatedLast && GetTime() - nStart > 60))
+            (nTransactionsUpdated != nTransactionsUpdatedLast && GetAdjustedTime() - nStart > 60))
         {
             if (pindexPrev != pindexBest)
             {
@@ -289,7 +289,7 @@ Value getwork(const Array& params, bool fHelp)
             // Store the pindexBest used before CreateNewBlock, to avoid races
             nTransactionsUpdatedLast = nTransactionsUpdated;
             CBlockIndex* pindexPrevNew = pindexBest;
-            nStart = GetTime();
+            nStart = GetAdjustedTime();
 
             // Create new block
             pblock = CreateNewBlock(pwalletMain);
@@ -408,7 +408,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
     static int64_t nStart;
     static CBlock* pblock;
     if (pindexPrev != pindexBest ||
-        (nTransactionsUpdated != nTransactionsUpdatedLast && GetTime() - nStart > 5))
+        (nTransactionsUpdated != nTransactionsUpdatedLast && GetAdjustedTime() - nStart > 5))
     {
         // Clear pindexPrev so future calls make a new block, despite any failures from here on
         pindexPrev = NULL;
@@ -416,7 +416,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
         // Store the pindexBest used before CreateNewBlock, to avoid races
         nTransactionsUpdatedLast = nTransactionsUpdated;
         CBlockIndex* pindexPrevNew = pindexBest;
-        nStart = GetTime();
+        nStart = GetAdjustedTime();
 
         // Create new block
         if(pblock)

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -96,6 +96,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("stake",         ValueFromAmount(pwalletMain->GetStake())));
     obj.push_back(Pair("blocks",        (int)nBestHeight));
     obj.push_back(Pair("timeoffset",    (int64_t)GetTimeOffset()));
+    obj.push_back(Pair("offsetfrom",    fNTPSuccess ? string("NTP") : (GetBoolArg("-synctime", false) ? string("Peers") : string("Local"))));
     obj.push_back(Pair("moneysupply",   ValueFromAmount(pindexBest->nMoneySupply)));
     obj.push_back(Pair("connections",   (int)vNodes.size()));
     obj.push_back(Pair("proxy",         (proxy.first.IsValid() ? proxy.first.ToStringIPPort() : string())));

--- a/src/stakedb.cpp
+++ b/src/stakedb.cpp
@@ -164,7 +164,7 @@ void ThreadFlushStakeDB(void* parg)
 
     unsigned int nLastSeen = nStakeDBUpdated;
     unsigned int nLastFlushed = nStakeDBUpdated;
-    int64_t nLastStakeUpdate = GetTime();
+    int64_t nLastStakeUpdate = GetAdjustedTime();
     while (!fShutdown)
     {
         MilliSleep(500);
@@ -172,10 +172,10 @@ void ThreadFlushStakeDB(void* parg)
         if (nLastSeen != nStakeDBUpdated)
         {
             nLastSeen = nStakeDBUpdated;
-            nLastStakeUpdate = GetTime();
+            nLastStakeUpdate = GetAdjustedTime();
         }
 
-        if (nLastFlushed != nStakeDBUpdated && GetTime() - nLastStakeUpdate >= 1)
+        if (nLastFlushed != nStakeDBUpdated && GetAdjustedTime() - nLastStakeUpdate >= 1)
         {
             TRY_LOCK(bitdb.cs_db,lockDb);
             if (lockDb)
@@ -263,7 +263,7 @@ bool CStakeDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
     // Rewrite salvaged data to wallet.dat
     // Set -rescan so any missing transactions will be
     // found.
-    int64_t now = GetTime();
+    int64_t now = GetAdjustedTime();
     std::string newFilename = strprintf("stake.%" PRId64 ".bak", now);
 
     int result = dbenv.dbenv.dbrename(NULL, filename.c_str(), NULL,

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1221,7 +1221,7 @@ void CompareTimeWithPeers(const std::vector<int64_t>& vSorted)
 
 void AddTimeData(const CNetAddr& ip, int64_t nTime, bool fSyncTime)
 {
-    int64_t nOffsetSample = nTime - GetAdjustedTime();
+    int64_t nOffsetSample = nTime - GetTime();
 
     // Ignore duplicates
     static set<CNetAddr> setKnown;

--- a/src/util.h
+++ b/src/util.h
@@ -21,6 +21,7 @@
 #include <string>
 
 #include <boost/thread.hpp>
+#include <boost/chrono.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/date_time/gregorian/gregorian_types.hpp>
@@ -206,6 +207,7 @@ uint64_t GetRand(uint64_t nMax);
 uint256 GetRandHash();
 int64_t GetTime();
 void SetMockTime(int64_t nMockTimeIn);
+void SetTimeOffset(const int64_t &nOffset);
 int64_t GetAdjustedTime();
 int64_t GetTimeOffset();
 std::string FormatFullVersion();

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -52,7 +52,7 @@ CPubKey CWallet::GenerateNewKey()
     CPubKey pubkey = key.GetPubKey();
 
     // Create new metadata
-    int64_t nCreationTime = GetTime();
+    int64_t nCreationTime = GetAdjustedTime();
     mapKeyMetadata[pubkey.GetID()] = CKeyMetadata(nCreationTime);
     if (!nTimeFirstKey || nCreationTime < nTimeFirstKey)
         nTimeFirstKey = nCreationTime;
@@ -1057,10 +1057,10 @@ void CWallet::ResendWalletTransactions(bool fForce)
         // Do this infrequently and randomly to avoid giving away
         // that these are our transactions.
         static int64_t nNextTime;
-        if (GetTime() < nNextTime)
+        if (GetAdjustedTime() < nNextTime)
             return;
         bool fFirst = (nNextTime == 0);
-        nNextTime = GetTime() + GetRand(30 * 60);
+        nNextTime = GetAdjustedTime() + GetRand(30 * 60);
         if (fFirst)
             return;
 
@@ -1068,7 +1068,7 @@ void CWallet::ResendWalletTransactions(bool fForce)
         static int64_t nLastTime;
         if (nTimeBestReceived < nLastTime)
             return;
-        nLastTime = GetTime();
+        nLastTime = GetAdjustedTime();
     }
 
     // Rebroadcast any of our txes that aren't in a block yet
@@ -2423,7 +2423,7 @@ bool CWallet::GetStakeWeight(const CKeyStore& keystore, uint64_t& nMinWeight, ui
     int64_t nValueIn = 0;
     
     
-    if (!SelectCoinsForStaking(nBalance - nReserveBalance, GetTime(), setCoins, nValueIn))
+    if (!SelectCoinsForStaking(nBalance - nReserveBalance, GetAdjustedTime(), setCoins, nValueIn))
         return false;
     
     if (setCoins.empty())
@@ -2442,7 +2442,7 @@ bool CWallet::GetStakeWeight(const CKeyStore& keystore, uint64_t& nMinWeight, ui
                 continue;
         }
 
-        int64_t nTimeWeight = GetWeight((int64_t)pcoin.first->nTime, (int64_t)GetTime());
+        int64_t nTimeWeight = GetWeight((int64_t)pcoin.first->nTime, (int64_t)GetAdjustedTime());
         // CBigNum bnCoinDayWeight = CBigNum(pcoin.first->vout[pcoin.second].nValue) * nTimeWeight / COIN / (24 * 60 * 60);
 
 
@@ -3219,7 +3219,7 @@ int64_t CWallet::GetOldestKeyPoolTime()
     CKeyPool keypool;
     ReserveKeyFromKeyPool(nIndex, keypool);
     if (nIndex == -1)
-        return GetTime();
+        return GetAdjustedTime();
     ReturnKey(nIndex);
     return keypool.nTime;
 }
@@ -3371,7 +3371,7 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, in
 		// presstab HyperStake
 		// This finds and deletes transactions that were never accepted by the network
 		// needs to be located above the readtxindex code or else it will not be triggered
-		if(!pcoin->IsConfirmedInMainChain() && (GetTime() - pcoin->GetTxTime()) > (60*10)) //give the tx 10 minutes before considering it failed
+		if(!pcoin->IsConfirmedInMainChain() && (GetAdjustedTime() - pcoin->GetTxTime()) > (60*10)) //give the tx 10 minutes before considering it failed
         {
            nOrphansFound++;
            if (!fCheckOnly)
@@ -3390,7 +3390,7 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, in
         for (unsigned int n=0; n < pcoin->vout.size(); n++)
         {
             bool fUpdated = false;
-            if (IsMine(pcoin->vout[n]) && pcoin->IsSpent(n) && (txindex.vSpent.size() <= n || txindex.vSpent[n].IsNull()) && (GetTime() - pcoin->GetTxTime()) > (60*10))
+            if (IsMine(pcoin->vout[n]) && pcoin->IsSpent(n) && (txindex.vSpent.size() <= n || txindex.vSpent[n].IsNull()) && (GetAdjustedTime() - pcoin->GetTxTime()) > (60*10))
             {
                 printf("FixSpentCoins found lost coin %spink %s[%d], %s\n",
                     FormatMoney(pcoin->vout[n].nValue).c_str(), hash.ToString().c_str(), n, fCheckOnly? "repair not attempted" : "repairing");
@@ -3403,7 +3403,7 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, in
                     pcoin->WriteToDisk();
                 }
             }
-            else if (IsMine(pcoin->vout[n]) && !pcoin->IsSpent(n) && (txindex.vSpent.size() > n && !txindex.vSpent[n].IsNull()) && (GetTime() - pcoin->GetTxTime()) > (60*10))
+            else if (IsMine(pcoin->vout[n]) && !pcoin->IsSpent(n) && (txindex.vSpent.size() > n && !txindex.vSpent[n].IsNull()) && (GetAdjustedTime() - pcoin->GetTxTime()) > (60*10))
             {
                 printf("FixSpentCoins found spent coin %shyp %s[%d], %s\n",
                     FormatMoney(pcoin->vout[n].nValue).c_str(), hash.ToString().c_str(), n, fCheckOnly? "repair not attempted" : "repairing");

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -10,7 +10,6 @@
 
 #include <stdlib.h>
 
-
 #include "main.h"
 #include "key.h"
 #include "keystore.h"
@@ -53,12 +52,12 @@ public:
 
     CKeyPool()
     {
-        nTime = GetTime();
+        nTime = GetAdjustedTime();
     }
 
     CKeyPool(const CPubKey& vchPubKeyIn)
     {
-        nTime = GetTime();
+        nTime = GetAdjustedTime();
         vchPubKey = vchPubKeyIn;
     }
 
@@ -836,7 +835,7 @@ public:
 
     CWalletKey(int64_t nExpires=0)
     {
-        nTimeCreated = (nExpires ? GetTime() : 0);
+        nTimeCreated = (nExpires ? GetAdjustedTime() : 0);
         nTimeExpires = nExpires;
     }
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -575,7 +575,7 @@ void ThreadFlushWalletDB(void* parg)
 
     unsigned int nLastSeen = nWalletDBUpdated;
     unsigned int nLastFlushed = nWalletDBUpdated;
-    int64_t nLastWalletUpdate = GetTime();
+    int64_t nLastWalletUpdate = GetAdjustedTime();
     while (!fShutdown)
     {
         MilliSleep(500);
@@ -583,10 +583,10 @@ void ThreadFlushWalletDB(void* parg)
         if (nLastSeen != nWalletDBUpdated)
         {
             nLastSeen = nWalletDBUpdated;
-            nLastWalletUpdate = GetTime();
+            nLastWalletUpdate = GetAdjustedTime();
         }
 
-        if (nLastFlushed != nWalletDBUpdated && GetTime() - nLastWalletUpdate >= 2)
+        if (nLastFlushed != nWalletDBUpdated && GetAdjustedTime() - nLastWalletUpdate >= 2)
         {
             TRY_LOCK(bitdb.cs_db,lockDb);
             if (lockDb)
@@ -674,7 +674,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
     // Rewrite salvaged data to wallet.dat
     // Set -rescan so any missing transactions will be
     // found.
-    int64_t now = GetTime();
+    int64_t now = GetAdjustedTime();
     std::string newFilename = strprintf("wallet.%" PRId64 ".bak", now);
 
     int result = dbenv.dbenv.dbrename(NULL, filename.c_str(), NULL,


### PR DESCRIPTION
Introduce NTP as the default for maintaining our internal time offset. Set everything internally to use AdjustedTime.  If we can't update from NTP we alert the user if our time is off from our peers, and users have the option to use -synctime to set their offset from peers if NTP fails.